### PR TITLE
fix(website/navbar/drawer): import onDestroy

### DIFF
--- a/apps/website/src/components/base/drawer.svelte
+++ b/apps/website/src/components/base/drawer.svelte
@@ -1,6 +1,7 @@
 <script>
   import CloseIcon from '@assets/base/close.svg?url'
   import LazyImage from '@shadcn/LazyImage/lazy-image.svelte'
+  import { onDestroy } from 'svelte'
 
   export let isOpen = false
   export let closeDrawer


### PR DESCRIPTION
Quick fix for the navbar

## Summary by Sourcery

Bug Fixes:
- Import the onDestroy lifecycle function in the drawer component to ensure proper cleanup.